### PR TITLE
fix apt conf prompt, unexpected operator warnings, and setup errors

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -68,7 +68,7 @@ if [ ! "$(which ansible-playbook)" ]; then
 
     # Install passlib for encrypt
     yum -y groupinstall "Development tools"
-    yum -y install python-devel MySQL-python sshpass && pip install pyrax pysphere boto passlib dnspython
+    yum -y install python-devel MySQL-python sshpass libffi-devel openssl-devel && pip install pyrax pysphere boto passlib dnspython
 
     # Install Ansible module dependencies
     yum -y install bzip2 file findutils git gzip hg svn sudo tar which unzip xz zip libselinux-python


### PR DESCRIPTION
This PR covers several things:
* If there is an older config file and a new packages prompts to update it (currently sudo on ubuntu 16.04 in bento/ubuntu-16.04 image), the script will pause waiting for user input. This sets the default option to preserve the current config and continue.
* There were a few benign `[: unexpected operator` that have been removed.
* The setup of cryptography package for python would fail. Installing a few additional packages resolves it.
* cleaned up a few small things with guidelines from shellcheck linter (https://github.com/koalaman/shellcheck)