### PR TITLE
Avoid error about non-existing /etc/system-release file

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -40,7 +40,7 @@ if [ "x$KITCHEN_LOG" = "xDEBUG" ] || [ "x$OMNIBUS_ANSIBLE_LOG" = "xDEBUG" ]; the
 fi
 
 if [ ! "$(which ansible-playbook)" ]; then
-  if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ] || grep -q 'Amazon Linux' /etc/system-release; then
+  if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
 
     # Install required Python libs and pip
     # Fix EPEL Metalink SSL error


### PR DESCRIPTION
When running the script with Test Kitchen, it show this error:
```
-----> Installing Ansible Omnibus
       downloading https://raw.githubusercontent.com/neillturner/omnibus-ansible/master/ansible_install.sh
         to file /tmp/ansible_install.sh
       trying wget...
       grep: /etc/system-release: No such file or directory
```
This is because of the quiet grep, but a non-existing file still triggers an error despite the quiet param. One solution would be to add the -s parameter to suppress errors, but I think the Amazon Linux check is superfluous unless I'm mistaken? Because there is already a check for /etc/system-release so in the case of Amazon Linux it will never reach that grep statement. It will however show an error on al other distro's that do not have that file.