### PR TITLE
Avoid warning about non-existing /etc/system-release

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -114,7 +114,7 @@ if [ ! "$(which ansible-playbook)" ]; then
   else
     pip install -q ansible=="$ANSIBLE_VERSION"
   fi
-  if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ] || grep -q 'Amazon Linux' /etc/system-release; then
+  if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
     # Fix for pycrypto pip / yum issue
     # https://github.com/ansible/ansible/issues/276
     if  ansible --version 2>&1  | grep -q "AttributeError: 'module' object has no attribute 'HAVE_DECL_MPZ_POWM_SEC'" ; then


### PR DESCRIPTION
This pull request is very similar to https://github.com/neillturner/omnibus-ansible/pull/15. I didn't see that there is another one of these giving warnings. This fixes that.