### PR TITLE
Avoid debconf frontend errors

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -30,8 +30,8 @@ dpkg_check_lock() {
 }
 
 apt_install() {
-  dpkg_check_lock && apt-get install -y -o DPkg::Options::=--force-confold \
-    -o DPkg::Options::=--force-confdef "$@"
+  dpkg_check_lock && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    -o DPkg::Options::=--force-confold -o DPkg::Options::=--force-confdef "$@"
 }
 
 if [ "x$KITCHEN_LOG" = "xDEBUG" ] || [ "x$OMNIBUS_ANSIBLE_LOG" = "xDEBUG" ]; then


### PR DESCRIPTION
Right now, the script spills out a bunch of errors related to debconf while installing, similar to the following:

https://github.com/phusion/baseimage-docker/issues/58

Setting the frontend to noninterative fixes this.