### PR TITLE
trusty support: force cryptography for python2

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -95,6 +95,7 @@ if [ ! "$(which ansible-playbook)" ]; then
 
     # Install passlib for encrypt
     apt_install build-essential
+    [ X`lsb_release -c | grep trusty | wc -l` = X1 ] && pip install cryptography==2.0.3
     apt_install python-all-dev python-mysqldb sshpass && pip install pyrax pysphere boto passlib dnspython
 
     # Install Ansible module dependencies


### PR DESCRIPTION

https://travis-ci.org/juju4/ansible-lufi/jobs/337233167#L3867
```
  Downloading cryptography-2.1.4.tar.gz (441kB): 441kB downloaded
         Running setup.py (path:/tmp/pip_build_root/cryptography/setup.py) egg_info for package cryptography
           error in cryptography setup command: Invalid environment marker: python_version < '3'
           Complete output from command python setup.py egg_info:
           error in cryptography setup command: Invalid environment marker: python_version < '3'
```

Need to force cryptography 2.0.3 to support python2