### PR TITLE
 Fix for passlib install breaking pip in Ubuntu 16.04

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -95,7 +95,7 @@ if [ ! "$(which ansible-playbook)" ]; then
 
     # Install passlib for encrypt
     apt_install build-essential
-    apt_install python-all-dev python-mysqldb sshpass && pip install pyrax pysphere boto passlib dnspython
+    apt_install python-all-dev python-mysqldb sshpass && pip install pyrax pysphere boto passlib dnspython pyopenssl
 
     # Install Ansible module dependencies
     apt_install bzip2 file findutils git gzip mercurial procps subversion sudo tar debianutils unzip xz-utils zip python-selinux python-boto


### PR DESCRIPTION
python-pip on ubuntu 16.04 breaks with:

    AttributeError: 'module' object has no attribute 'SSL_ST_INIT'

...after passlib install in ansible-omnibus.  One of the dependencies appears locked to an older version of the requests module.

Adding pyopenssl to the passlib install step appears to keep pip working.

Adding python-boto to allow ansible-kitchen to work with dynamic inventory scripts which might include queries to AWS ec2.py 
Resolves: https://github.com/neillturner/kitchen-ansible/issues/260
