### PR TITLE
Add openSUSE Tumbleweed Support

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -101,7 +101,7 @@ if [ ! "$(which ansible-playbook)" ]; then
     # Install Ansible module dependencies
     apt_install bzip2 file findutils git gzip mercurial procps subversion sudo tar debianutils unzip xz-utils zip python-selinux python-boto
 
-  elif [ -f /etc/SuSE-release ] ; then
+  elif [ -f /etc/SuSE-release ] || grep -qi opensuse /etc/os-release; then
     zypper --quiet --non-interactive refresh
 
     # Install required Python libs and pip


### PR DESCRIPTION
sh-5.0# stat /etc/SuSe-release
stat: cannot stat '/etc/SuSe-release': No such file or directory
sh-5.0# cat /etc/os-release
NAME="openSUSE Tumbleweed"
