### PR TITLE
Add missing python-xml and rpm-python

### DIFF
--- a/ansible_install.sh
+++ b/ansible_install.sh
@@ -105,7 +105,7 @@ if [ ! "$(which ansible-playbook)" ]; then
     zypper --quiet --non-interactive refresh
 
     # Install required Python libs and pip
-    zypper --quiet --non-interactive install libffi-devel openssl-devel python-devel perl-Error
+    zypper --quiet --non-interactive install libffi-devel openssl-devel python-devel perl-Error python-xml rpm-python
     zypper --quiet --non-interactive install git || zypper --quiet --non-interactive install git-core
 
     # If python-pip install failed and setuptools exists, try that


### PR DESCRIPTION
Followup to the previous one, seems we need some additional packages

```
       fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not detect a supported package manager from the following list: ['portage', 'rpm', 'pkg', 'apt'], or the required Python library is not installed. Check warnings for details."}
```